### PR TITLE
Fix mappings for workflow index

### DIFF
--- a/cwl-metrics
+++ b/cwl-metrics
@@ -239,13 +239,17 @@ create_index_workflow() {
     },
     "mappings": {
       "properties": {
-        "start_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd HH:mm:ss"
-        },
-        "end_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd HH:mm:ss"
+        "workflow": {
+          "properties": {
+            "start_date": {
+              "type": "date",
+              "format": "yyyy-MM-dd HH:mm:ss"
+            },
+            "end_date": {
+              "type": "date",
+              "format": "yyyy-MM-dd HH:mm:ss"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Currently `create_index_workflow` sets mappings for `start_date` and `end_date` in `workflow` index but there are no such fields in the root of metrics entries.
This request fixes them to set mappings for `workflow.start_date` and `workflow.end_date` in `workflow` index.


